### PR TITLE
Search for SBOM roots across repository

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/vinted/software-assets
+
+go 1.17
+
+require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/handlers/ruby/bundler.go
+++ b/handlers/ruby/bundler.go
@@ -1,0 +1,14 @@
+package ruby
+
+const Gemfile = "Gemfile"
+const GemfileLock = "Gemfile.lock"
+
+type Handler interface {
+	SupportsFile()
+}
+
+type Bundler struct{}
+
+func (b Bundler) SupportsFile(filepath string) bool {
+	return filepath == Gemfile || filepath == GemfileLock
+}

--- a/handlers/ruby/bundler_test.go
+++ b/handlers/ruby/bundler_test.go
@@ -1,0 +1,13 @@
+package ruby
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSupportsFile(t *testing.T) {
+	bundler := Bundler{}
+	assert.True(t, bundler.SupportsFile(Gemfile))
+	assert.True(t, bundler.SupportsFile(GemfileLock))
+	assert.False(t, bundler.SupportsFile("/etc/passwd"))
+}

--- a/utils/collections.go
+++ b/utils/collections.go
@@ -1,0 +1,12 @@
+package utils
+
+// Keys returns all keys from the map in unpredictable order
+func Keys(target map[string]bool) []string {
+	keys := make([]string, len(target))
+	i := 0
+	for k := range target {
+		keys[i] = k
+		i++
+	}
+	return keys
+}

--- a/utils/collections_test.go
+++ b/utils/collections_test.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestKeys(t *testing.T) {
+	key1 := "key-1"
+	key2 := "key-2"
+	key3 := "key-3"
+	got := Keys(map[string]bool{key1: true, key2: true, key3: true})
+	assert.ElementsMatch(t, []string{key1, key2, key3}, got)
+}

--- a/utils/repositories.go
+++ b/utils/repositories.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"io/fs"
+	"path/filepath"
+)
+
+// GatherSBOMRoots walks the given repository path and calls predicate
+// function for each file. Predicate functions gives clients a chance to
+// tell which particular Package Manager files denote SBOM collection root.
+// If a predicate function return true for a give file, the directory of that
+// file gets included the return slice.
+func GatherSBOMRoots(repoPath string, predicate func(string) bool) ([]string, error) {
+	var collectionPaths = make(map[string]bool)
+	err := filepath.WalkDir(repoPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if baseName := filepath.Base(path); predicate(baseName) && !d.IsDir() {
+			collectionPaths[filepath.Dir(path)] = true
+		}
+		return nil
+	})
+	return Keys(collectionPaths), err
+}

--- a/utils/repositories_test.go
+++ b/utils/repositories_test.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestGatherSBOMRoots(t *testing.T) {
+
+	predicate := func(filepath string) bool {
+		return filepath == "Packages" || filepath == "Packages.lock"
+	}
+
+	t.Run("existing repository", func(t *testing.T) {
+		got, err := GatherSBOMRoots("test-repository", predicate)
+		require.Nil(t, err)
+		require.ElementsMatch(t, []string{"test-repository", "test-repository/inner-dir/deepest-dir"}, got)
+	})
+	t.Run("non-existing repository", func(t *testing.T) {
+		_, err := GatherSBOMRoots("/non-existing", predicate)
+		require.NotNil(t, err)
+	})
+}

--- a/utils/test-repository/Packages
+++ b/utils/test-repository/Packages
@@ -1,0 +1,1 @@
+Used by GatherSBOMRoots test - this file should represent SBOM root

--- a/utils/test-repository/Packages.lock
+++ b/utils/test-repository/Packages.lock
@@ -1,0 +1,1 @@
+Used by GatherSBOMRoots test - this file should represent SBOM root

--- a/utils/test-repository/ignore.txt
+++ b/utils/test-repository/ignore.txt
@@ -1,0 +1,1 @@
+Used by GatherSBOMRoots test - this file should not represent SBOM root

--- a/utils/test-repository/inner-dir/deepest-dir/Packages.lock
+++ b/utils/test-repository/inner-dir/deepest-dir/Packages.lock
@@ -1,0 +1,1 @@
+Used by GatherSBOMRoots test - this file should represent SBOM root


### PR DESCRIPTION
Implement a reusable mechanism for walking through a
repository and searching for SBOM roots via a predicate.
This predicate will be supplied depending on the package
manager being tested.