### PR TITLE
Implement Filesystem SBOM extraction

### DIFF
--- a/cmd/fs.go
+++ b/cmd/fs.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+
+	"github.com/spf13/cobra"
+	"github.com/vinted/software-assets/internal"
+)
+
+var fsCmd = &cobra.Command{
+	Use:   "fs [Filesystem path] [flags]",
+	Short: "Collect SBOMs from a filesystem path",
+	Example: `sa-collector fs /usr/local/bin
+sa-collector fs / --exclude './root' --log-level=warn`,
+	Long: "Collect SBOMs from a filesystem path." + subCommandHelpMsg,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return errors.New("a valid filesystem path is required")
+		}
+
+		if _, err := os.Stat(args[0]); err != nil {
+			return err
+		}
+
+		return cobra.MaximumNArgs(1)(cmd, args)
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		internal.SBOMsFromFilesystem(args[0])
+	},
+}
+
+func init() {
+	const exclude = "exclude"
+	fsCmd.Flags().StringArrayP(exclude, "e", nil, "exclude paths from being scanned using a glob expression")
+
+	if err := viper.BindPFlag(exclude, fsCmd.Flags().Lookup(exclude)); err != nil {
+		logrus.Fatalf(cantBindFlagTemplate, exclude, err)
+	}
+
+	rootCmd.AddCommand(fsCmd)
+}

--- a/cmd/org.go
+++ b/cmd/org.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 
 	"github.com/sirupsen/logrus"
@@ -35,7 +34,6 @@ func init() {
 	orgCmd.Flags().BoolP(delayFlag, "d", false, "whether to add a random delay when cloning repos")
 	if err := viper.BindPFlag(delayFlag, orgCmd.Flags().Lookup(delayFlag)); err != nil {
 		logrus.Fatalf(cantBindFlagTemplate, delayFlag, err)
-		os.Exit(1)
 	}
 	rootCmd.AddCommand(orgCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,10 @@ var rootCmd = &cobra.Command{
 sa-collector repo https://github.com/ffuf/ffuf --output=dtrack      collect SBOMs from ffuf repository & upload them to Dependency Track
 
 sa-collector org evil-corp                                          collect SBOMs from evil-corp organization & output them to stdout
-sa-collector org evil-corp --output=dtrack                          collect SBOMs from evil-corp organization & upload them to Dependency Track`,
+sa-collector org evil-corp --output=dtrack                          collect SBOMs from evil-corp organization & upload them to Dependency Track
+
+sa-collector fs /usr/local/bin                                      collect SBOMs recursively from /usr/local/bin directory
+sa-collector fs / --exclude './root'                                collect SBOMs recursively from root directory while excluding /root directory`,
 }
 
 func Execute() {
@@ -87,7 +90,6 @@ func init() {
 
 	if err := viper.BindPFlag(outputFlag, rootCmd.PersistentFlags().Lookup(outputFlag)); err != nil {
 		logrus.Fatalf(cantBindFlagTemplate, outputFlag, err)
-		os.Exit(1)
 	}
 }
 

--- a/pkg/collectors/syft.go
+++ b/pkg/collectors/syft.go
@@ -13,7 +13,9 @@ import (
 	"github.com/vinted/software-assets/pkg/bomtools"
 )
 
-type Syft struct{}
+type Syft struct {
+	Exclusions []string
+}
 
 type sbomCollectionResult struct {
 	sbom *cdx.BOM
@@ -30,7 +32,7 @@ func (s Syft) generateBOMInternal(ctx context.Context, repositoryPath string, re
 		ImageSource: image.UnknownSource,
 		Platform:    "",
 	}
-	src, _, err := source.New(input, nil, nil)
+	src, _, err := source.New(input, nil, s.Exclusions)
 	if err != nil {
 		err = fmt.Errorf("%s repository path is invalid: %v\n", repositoryPath, err)
 		select {


### PR DESCRIPTION
Previously we could only extract SBOMs from GitHub repositories.
This commit now allows SBOM extraction from filesystems with fs subcommand.