### PR TITLE
Refactor reused string literals

### DIFF
--- a/cmd/fs.go
+++ b/cmd/fs.go
@@ -37,7 +37,7 @@ func init() {
 	const exclude = "exclude"
 	fsCmd.Flags().StringArrayP(exclude, "e", nil, "exclude paths from being scanned using a glob expression")
 
-	if err := viper.BindPFlag(exclude, fsCmd.Flags().Lookup(exclude)); err != nil {
+	if err := viper.BindPFlag(internal.CLIKeyExclusions, fsCmd.Flags().Lookup(exclude)); err != nil {
 		logrus.Fatalf(cantBindFlagTemplate, exclude, err)
 	}
 

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -1,0 +1,24 @@
+package internal
+
+// Viper CLI keys
+const (
+	CLIKeyExclusions        = "cli-key-exclusions"
+	CLIKeyOutput            = "cli-key-output"
+	CLIKeyDTrackProjectName = "cli-key-dtrack-project-name"
+)
+
+// Output values for CLI --output switch
+const (
+	OutputValueStdout = "stdout"
+	OutputValueDtrack = "dtrack"
+)
+
+// Viper ENV keys
+const (
+	EnvKeyGithubUsername = "GITHUB_USERNAME"
+	EnvKeyGithubToken    = "GITHUB_TOKEN"
+	EnvKeyDTrackURL      = "DEPENDENCY_TRACK_URL"
+	EnvKeyDTrackToken    = "DEPENDENCY_TRACK_TOKEN"
+)
+
+const EnvPrefix = "SAC" // Software Asset Collector


### PR DESCRIPTION
Previously there were many places where string literals were used.
This was problematic since changing string values in one place would cause bugs.
This commit removes string literals in favor of constants