### PR TITLE
Refactor DT HTTP operations to its own file

### DIFF
--- a/pkg/clients/dependency_track.go
+++ b/pkg/clients/dependency_track.go
@@ -1,0 +1,134 @@
+package clients
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"time"
+)
+
+const (
+	uploadSBOMsPath = "/api/v1/bom"
+)
+
+type DependencyTrackClient struct {
+	baseURL, apiToken string
+	requestTimeout    time.Duration
+}
+
+type options struct {
+	requestTimeout time.Duration
+}
+
+type Option func(options *options) error
+
+// WithRequestTimeout add a request timeout in seconds.
+func WithRequestTimeout(requestTimeout int) Option {
+	return func(options *options) error {
+		if requestTimeout <= 0 {
+			return errors.New("request timeout must be higher than zero")
+		}
+
+		options.requestTimeout = time.Second * time.Duration(requestTimeout)
+
+		return nil
+	}
+}
+
+func NewDependencyTrackClient(baseURL, apiToken string, opts ...Option) (*DependencyTrackClient, error) {
+	if _, err := url.Parse(baseURL); err != nil { // Validate supplied URL early on
+		return nil, fmt.Errorf("can't parse base URL: %w", err)
+	}
+
+	if apiToken == "" {
+		return nil, errors.New("api token can't be empty")
+	}
+
+	var options options
+	for _, opt := range opts {
+		err := opt(&options)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	client := new(DependencyTrackClient)
+
+	// Mandatory parameters
+	client.baseURL = baseURL
+	client.apiToken = apiToken
+	// Optional parameters
+	const defaultTimeout = 30
+
+	if options.requestTimeout == 0 {
+		client.requestTimeout = time.Second * time.Duration(defaultTimeout)
+	} else {
+		client.requestTimeout = options.requestTimeout
+	}
+
+	return client, nil
+}
+
+/*UploadSBOMs uploads SBOMs to Dependency Track.
+projectName - Dependency Track project name to use.
+autoCreate - Automatically create project in Dependency Track if it doesn't exist.
+sboms - SBOMs to upload, must be a valid CycloneDX JSON string.
+*/
+func (d DependencyTrackClient) UploadSBOMs(ctx context.Context, projectName string, autoCreate bool, sboms string) error {
+	baseURL, _ := url.Parse(d.baseURL) // Ignore error - we already validated base URL earlier on
+	baseURL.Path = path.Join(baseURL.Path, uploadSBOMsPath)
+	uploadURL := baseURL.String()
+
+	ctx, cancel := context.WithTimeout(ctx, d.requestTimeout)
+	defer cancel()
+	// Build the required payload for Dependency Track
+	payload, err := json.Marshal(map[string]string{
+		"projectName":    projectName,
+		"autoCreate":     strconv.FormatBool(autoCreate),
+		"projectVersion": time.Now().Format("2006-01-02 15:04:05"),
+		"bom":            base64.StdEncoding.EncodeToString([]byte(sboms)),
+	})
+	if err != nil {
+		return fmt.Errorf("can't construct JSON payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, bytes.NewBuffer(payload))
+	if err != nil {
+		return fmt.Errorf("can't construct HTTP request: %w", err)
+	}
+
+	req.Header.Set("X-Api-Key", d.apiToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+
+	defer func() {
+		closeErr := resp.Body.Close()
+		if err != nil {
+			if closeErr != nil {
+				err = fmt.Errorf("UploadSBOMs: %w can't close response body %v", err, closeErr)
+			}
+			return
+		}
+		err = closeErr
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		// Don't return the error straight up - mind the defer above
+		err = BadStatusError{Status: resp.StatusCode, URL: uploadURL}
+
+		return err
+	}
+
+	return err
+}

--- a/pkg/clients/dependency_track_test.go
+++ b/pkg/clients/dependency_track_test.go
@@ -1,0 +1,127 @@
+package clients
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDependencyTrackClientCreation(t *testing.T) {
+	t.Run("return an error when creating a client with invalid URL", func(t *testing.T) {
+		client, err := NewDependencyTrackClient("https://invalid url.com", "token")
+
+		var e url.InvalidHostError
+		assert.ErrorAs(t, err, &e)
+		assert.Nil(t, client)
+	})
+
+	t.Run("return an error when creating a client with empty API token", func(t *testing.T) {
+		client, err := NewDependencyTrackClient("https://url.com", "")
+
+		assert.Nil(t, client)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("apply request timeout option when it's set", func(t *testing.T) {
+		const timeout = 666
+		client, _ := NewDependencyTrackClient("https://url.com", "token", WithRequestTimeout(timeout))
+
+		assert.Equal(t, time.Second*time.Duration(timeout), client.requestTimeout)
+	})
+}
+
+// Test payload for SBOMs upload.
+const (
+	autoCreate   = true
+	sbomsContent = "sample-sboms-for-testing"
+	projectName  = "sample-project-name-for-testing"
+)
+
+// Helper function for uploading SBOMs.
+func executeSBOMsUpload(t *testing.T, endpoint, apiKey string) error {
+	t.Helper()
+
+	client, err := NewDependencyTrackClient(endpoint, apiKey)
+	if err != nil {
+		t.Fatalf("can't create dependency track client: %s", err)
+	}
+
+	return client.UploadSBOMs(context.Background(), projectName, autoCreate, sbomsContent)
+}
+
+func TestUploadSBOMs(t *testing.T) {
+	const apiKeyForTesting = "some-random-api-key"
+
+	t.Run("construct HTTP payload correctly", func(t *testing.T) {
+		type uploadSBOMsPayload struct {
+			AutoCreate, Bom, ProjectName, ProjectVersion string
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			res.WriteHeader(http.StatusOK)
+
+			var got uploadSBOMsPayload
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&got)) // Decode into got var
+
+			assert.NotEmpty(t, got.ProjectVersion)
+			assert.Equal(t, projectName, got.ProjectName)
+			assert.Equal(t, strconv.FormatBool(autoCreate), got.AutoCreate)
+			assert.Equal(t, base64.StdEncoding.EncodeToString([]byte(sbomsContent)), got.Bom)
+		}))
+		defer server.Close()
+
+		_ = executeSBOMsUpload(t, server.URL, apiKeyForTesting)
+	})
+
+	t.Run("return BadStatusError on non 200 OK responses", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			res.WriteHeader(http.StatusTeapot)
+		}))
+		defer server.Close()
+
+		err := executeSBOMsUpload(t, server.URL, apiKeyForTesting)
+
+		var e BadStatusError
+		assert.ErrorAs(t, err, &e)
+	})
+
+	t.Run("return nil error on successful 200 OK responses", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			res.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		err := executeSBOMsUpload(t, server.URL, apiKeyForTesting)
+		assert.NoError(t, err)
+	})
+
+	t.Run("append '/api/v1/bom' to base URL when uploading SBOMs", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			res.WriteHeader(http.StatusOK)
+			assert.Equal(t, "/api/v1/bom", req.URL.Path)
+		}))
+		defer server.Close()
+
+		_ = executeSBOMsUpload(t, server.URL, apiKeyForTesting)
+	})
+
+	t.Run("set X-Api-Key & Content-Type request headers correctly", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			res.WriteHeader(http.StatusOK)
+			assert.Equal(t, apiKeyForTesting, req.Header.Get("X-Api-Key"))
+			assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
+		}))
+		defer server.Close()
+
+		_ = executeSBOMsUpload(t, server.URL, apiKeyForTesting)
+	})
+}

--- a/pkg/clients/types.go
+++ b/pkg/clients/types.go
@@ -1,0 +1,12 @@
+package clients
+
+import "fmt"
+
+type BadStatusError struct {
+	URL    string
+	Status int
+}
+
+func (b BadStatusError) Error() string {
+	return fmt.Sprintf("did not get 200 from %s, got %d", b.URL, b.Status)
+}


### PR DESCRIPTION
Previously Dependency Track & GitHub HTTP operations were in a single
file. This was ok for a while but now is becoming a problem. Later on,
Dependency Track HTTP operations will expand with project & owner tagging.
To keep this tidy & prevent future clutter - this commit extracts DT operations
to its own client