### PR TITLE
Don't version projects in Dependency Track

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -309,32 +309,17 @@ func (a App) uploadSBOMsToDependencyTrack(ctx context.Context, projectName strin
 		return
 	}
 
-	const errMsg = "can't upload SBOMs to Dependency Track"
-
-	projectUUID, err := a.dependencyTrackClient.CreateProject(ctx, dtrack.CreateProjectPayload{
-		Tags:       a.tags,
-		CodeOwners: codeOwners,
-		Name:       projectName,
-	})
-
-	if errors.Is(err, context.Canceled) {
-		return
-	} else if err != nil {
-		log.WithField("reason", err).Error(errMsg)
-
-		return
-	}
-
-	err = a.dependencyTrackClient.UploadSBOMs(ctx, dtrack.UploadSBOMsPayload{
+	err := a.dependencyTrackClient.UploadSBOMs(ctx, dtrack.UploadSBOMsPayload{
 		Sboms:       sboms,
-		ProjectUUID: projectUUID,
+		ProjectName: projectName,
+		Tags:        a.tags,
+		CodeOwners:  codeOwners,
 	})
 
 	if errors.Is(err, context.Canceled) {
 		return
 	} else if err != nil {
-		log.WithField("reason", err).Error(errMsg)
-
+		log.WithField("reason", err).Error("can't upload SBOMs to Dependency Track")
 		return
 	}
 

--- a/internal/requests_test.go
+++ b/internal/requests_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/vinted/software-assets/pkg"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -76,7 +78,7 @@ func TestGetRepositories(t *testing.T) {
 
 	// Errors path
 	t.Run("return BadStatusError on non 200 OK responses", func(t *testing.T) {
-		const errorTemplate = "did not get 200 from %s, got %d"
+		const errorTemplate = "did not get a successful response from %s, got %d"
 		hitCounter := 0
 		teapotServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 			hitCounter++
@@ -85,7 +87,7 @@ func TestGetRepositories(t *testing.T) {
 		defer teapotServer.Close()
 		repositories, err := GetRepositories(createGetRepositoriesConfig(teapotServer.URL))
 
-		assert.ErrorIs(t, err, BadStatusError{URL: teapotServer.URL, Status: http.StatusTeapot})
+		assert.ErrorIs(t, err, pkg.BadStatusError{URL: teapotServer.URL, Status: http.StatusTeapot})
 		assert.Empty(t, repositories)
 		assert.Equal(t, 1, hitCounter)
 		assert.Equal(t, fmt.Sprintf(errorTemplate, teapotServer.URL, http.StatusTeapot), err.Error())

--- a/pkg/dtrack/http_test.go
+++ b/pkg/dtrack/http_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/vinted/software-assets/pkg"
+
 	cdx "github.com/CycloneDX/cyclonedx-go"
 
 	"github.com/stretchr/testify/assert"
@@ -23,12 +25,13 @@ func executeSBOMsUpload(t *testing.T, endpoint, apiKey string) error {
 		t.Fatalf("can't create dependency track client: %s", err)
 	}
 
-	payload := UploadSBOMsPayload{
+	payload := updateSBOMsPayload{
 		Sboms:       new(cdx.BOM),
-		ProjectUUID: "e1e690f9-e4fb-4ef8-9148-e86fff1b23ff",
+		ProjectName: "some-random-project-name",
+		Tags:        []string{"some-random-project-tag"},
 	}
 
-	return client.UploadSBOMs(context.Background(), payload)
+	return client.updateSBOMs(context.Background(), payload)
 }
 
 // Helper function for creating a project
@@ -40,7 +43,7 @@ func executeCreateProject(t *testing.T, endpoint, apiKey string) (string, error)
 		t.Fatalf("can't create dependency track client: %s", err)
 	}
 
-	return client.CreateProject(context.Background(), CreateProjectPayload{})
+	return client.createProject(context.Background(), createProjectPayload{})
 }
 
 func TestAppendURLPath(t *testing.T) {
@@ -72,7 +75,7 @@ func TestCreateProject(t *testing.T) {
 
 		_, err := executeCreateProject(t, server.URL, apiKeyForTesting)
 
-		var e BadStatusError
+		var e pkg.BadStatusError
 		assert.ErrorAs(t, err, &e)
 	})
 
@@ -135,7 +138,7 @@ func TestUploadSBOMs(t *testing.T) {
 
 		err := executeSBOMsUpload(t, server.URL, apiKeyForTesting)
 
-		var e BadStatusError
+		var e pkg.BadStatusError
 		assert.ErrorAs(t, err, &e)
 	})
 

--- a/pkg/dtrack/payloads_test.go
+++ b/pkg/dtrack/payloads_test.go
@@ -1,9 +1,9 @@
 package dtrack
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -13,14 +13,15 @@ import (
 )
 
 func TestMarshal(t *testing.T) {
-	t.Run("marshal CreateProjectPayload instances correctly", func(t *testing.T) {
-		const (
-			testProjectName      = "some-random-project-name"
-			testProjectTag       = "some-random-project-tag"
-			testProjectCodeOwner = "some-random-code-owner"
-		)
+	const (
+		testProjectName      = "some-random-project-name"
+		testProjectTag       = "some-random-project-tag"
+		testProjectCodeOwner = "some-random-code-owner"
+		sbomsB64             = "ewogICJib21Gb3JtYXQiOiAiIiwKICAic3BlY1ZlcnNpb24iOiAiIiwKICAidmVyc2lvbiI6IDAKfQo="
+	)
 
-		got, err := json.Marshal(CreateProjectPayload{
+	t.Run("marshal createProjectPayload instances correctly", func(t *testing.T) {
+		got, err := json.Marshal(createProjectPayload{
 			Name:       testProjectName,
 			CodeOwners: []string{testProjectCodeOwner},
 			Tags:       []string{testProjectTag},
@@ -46,28 +47,32 @@ func TestMarshal(t *testing.T) {
 		assert.Equal(t, testProjectName, u.Name)
 		assert.Equal(t, "CODE OWNERS:\n"+testProjectCodeOwner, u.CodeOwners)
 		assert.Equal(t, []projectTag{{Name: testProjectTag}}, u.Tags)
-		// Don't check the actual date as it always changes - just assert on regex
-		assert.Regexp(t, regexp.MustCompile(`\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}`), u.Version)
+
+		// Version is the sha256 sum of project tags joined together with "/" + projectName
+		projectVersion := strings.Join(append([]string{testProjectTag}, testProjectName), "/")
+		assert.Equal(t, fmt.Sprintf("%x", sha256.Sum256([]byte(projectVersion))), u.Version)
 	})
 
-	t.Run("marshal UploadSBOMsPayload instances correctly", func(t *testing.T) {
-		const (
-			projectUUID = "9488d60b-eb11-4569-8a7c-129d37b111e3"
-			sbomsB64    = "ewogICJib21Gb3JtYXQiOiAiIiwKICAic3BlY1ZlcnNpb24iOiAiIiwKICAidmVyc2lvbiI6IDAKfQo="
-		)
-
-		got, err := json.Marshal(UploadSBOMsPayload{
+	t.Run("marshal updateSBOMsPayload instances correctly", func(t *testing.T) {
+		got, err := json.Marshal(updateSBOMsPayload{
 			Sboms:       new(cdx.BOM), // zeroed mem value - b64 is always the same
-			ProjectUUID: projectUUID,
+			ProjectName: testProjectName,
+			Tags:        []string{testProjectTag},
 		})
 		require.NoError(t, err)
-		assert.Equal(t, fmt.Sprintf("{\"bom\":\"%s\",\"project\":\"%s\"}", sbomsB64, projectUUID), string(got))
+
+		template := "{\"bom\":\"%s\",\"projectName\":\"%s\",\"projectVersion\":\"%s\"}"
+		// Version is the sha256 sum of project tags joined together with "/" + projectName
+		projectVersion := strings.Join(append([]string{testProjectTag}, testProjectName), "/")
+		expectedProjectVersion := fmt.Sprintf("%x", sha256.Sum256([]byte(projectVersion)))
+
+		assert.Equal(t, fmt.Sprintf(template, sbomsB64, testProjectName, expectedProjectVersion), string(got))
 	})
 }
 
 func TestGetTruncatedCodeOwners(t *testing.T) {
 	t.Run("filter out emails with 'users.noreply.github.com' domains", func(t *testing.T) {
-		got := CreateProjectPayload{
+		got := createProjectPayload{
 			Name:       "some-random-name",
 			Tags:       nil,
 			CodeOwners: []string{"7+test@users.noreply.github.com", "john.doe@example.com", "jane.doe@pm.me"},
@@ -78,7 +83,7 @@ func TestGetTruncatedCodeOwners(t *testing.T) {
 	})
 
 	t.Run("filter out emails that contain unicode characters", func(t *testing.T) {
-		got := CreateProjectPayload{
+		got := createProjectPayload{
 			Name:       "some-random-name",
 			Tags:       nil,
 			CodeOwners: []string{"7+test@ačiū.com", "john.doe@example.com", "jane.doe@pm.me"},
@@ -89,7 +94,7 @@ func TestGetTruncatedCodeOwners(t *testing.T) {
 	})
 
 	t.Run("order vinted.com contributors at the top", func(t *testing.T) {
-		got := CreateProjectPayload{
+		got := createProjectPayload{
 			Name:       "some-random-name",
 			Tags:       nil,
 			CodeOwners: []string{"john.doe@pm.me", "john.smith@acme.com", "jane.doe@vinted.com", "jane@vinted.com"},
@@ -100,7 +105,7 @@ func TestGetTruncatedCodeOwners(t *testing.T) {
 	})
 
 	t.Run("truncate code owners to a maximum of 255 characters", func(t *testing.T) {
-		got := CreateProjectPayload{
+		got := createProjectPayload{
 			Name:       "some-random-name",
 			Tags:       nil,
 			CodeOwners: []string{strings.Repeat("A", 300)}, // 300 A's

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -1,0 +1,12 @@
+package pkg
+
+import "fmt"
+
+type BadStatusError struct {
+	URL    string
+	Status int
+}
+
+func (b BadStatusError) Error() string {
+	return fmt.Sprintf("did not get a successful response from %s, got %d", b.URL, b.Status)
+}


### PR DESCRIPTION
Previously each project was versioned based on current timestamp. This resulted
in multiple same projects created & additional clutter in Dependency Track.
This commit removes Date versioning in favor of same hash versioning.

Signed-off-by: Ugnius Vaznys <ugnius.vaznys@vinted.com>