### PR TITLE
Update GitHub actions

### DIFF
--- a/build/push-to-cloudsmith.sh
+++ b/build/push-to-cloudsmith.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 releaseVersion=$(echo "$RELEASE" | tr '/' -)
-releaseName="sa-collector-$releaseVersion-$GOOS-$GOARCH.tar.gz"
-go build -ldflags "-s -w" -o sa-collector && tar -czvf "$releaseName" sa-collector
+releaseName="sa-collector-$releaseVersion-$GOOS-$GOARCH"
+
+go build -ldflags "-s -w" -o "$releaseName"
 
 pip3 install cloudsmith-cli
 cloudsmith push raw vinted/raw-hosted-security "$releaseName"


### PR DESCRIPTION
Previously whole .tar.gz package was pushed to cloud-smith instead of a single binary. This added more moving parts and eventually caused a checksum mismatch conflict in chef. This commit removes .tar.gz packaging in favor of a single binary. Since artifacts are already cached by cloud-smith we won't waste a lot of bandwidth, but we will simplify chef deployment process.

Signed-off-by: Ugnius Vaznys <ugnius.vaznys@vinted.com>