### PR TITLE
Strip trailing checksum from PURLs & CPEs

### DIFF
--- a/integration/test/bomtools/normalize-cpes-bom.json
+++ b/integration/test/bomtools/normalize-cpes-bom.json
@@ -1,0 +1,108 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "serialNumber": "urn:uuid:4ef2f273-e0f7-4ce6-a34b-6d07b92ec8c6",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2022-04-27T09:43:27.861Z",
+    "tools": [
+      {
+        "vendor": "AppThreat",
+        "name": "cdxgen",
+        "version": "4.0.11"
+      }
+    ],
+    "authors": [
+      {
+        "name": "Team AppThreat",
+        "email": "cloud@appthreat.com"
+      }
+    ]
+  },
+  "components": [
+    {
+      "bom-ref": "pkg:golang/github.com/pelletier/go-toml@v1.8.1",
+      "type": "library",
+      "name": "github.com/pelletier/go-toml",
+      "version": "v1.8.1",
+      "hashes": [],
+      "licenses": [],
+      "cpe": "cpe:2.3:a:pelletier:go-toml:v1.8.1:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/pelletier/go-toml@v1.8.1",
+      "externalReferences": [],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-mod-file-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:pelletier:go_toml:v1.8.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "go.mod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/next@11.1.4_6ae8aab56bccab9c135b13f4dcebcfdd",
+      "type": "library",
+      "name": "next",
+      "version": "11.1.4_6ae8aab56bccab9c135b13f4dcebcfdd",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "196409ad66247c028ff2f9abcc97027d148abfde792a1ca3a9de638a94dc54a0c683e487f8d7e30cc585b42c00adc4251cfbf38ac1aed4444b634f84a23ec6fa"
+        }
+      ],
+      "licenses": [],
+      "cpe": "cpe:2.3:a:next:next:11.1.4_6ae8aab56bccab9c135b13f4dcebcfdd:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/next@11.1.4_6ae8aab56bccab9c135b13f4dcebcfdd",
+      "externalReferences": [],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-lock-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "javascript"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "npm"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:*:next:11.1.4_6ae8aab56bccab9c135b13f4dcebcfdd:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "client/pnpm-lock.yaml"
+        }
+      ]
+    }
+  ],
+  "externalReferences": [
+    {
+      "type": "other",
+      "url": ".",
+      "comment": "Base path"
+    },
+    {
+      "type": "other",
+      "url": "/tmp/checkouts/lighthouse-ci-action/yarn.lock",
+      "comment": "Package file"
+    }
+  ]
+}

--- a/integration/test/bomtools/normalize-purls-bom.json
+++ b/integration/test/bomtools/normalize-purls-bom.json
@@ -157,6 +157,45 @@
           "value": "go.mod"
         }
       ]
+    },
+    {
+      "bom-ref": "pkg:npm/next@11.1.4_6ae8aab56bccab9c135b13f4dcebcfdd",
+      "type": "library",
+      "name": "next",
+      "version": "11.1.4_6ae8aab56bccab9c135b13f4dcebcfdd",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "196409ad66247c028ff2f9abcc97027d148abfde792a1ca3a9de638a94dc54a0c683e487f8d7e30cc585b42c00adc4251cfbf38ac1aed4444b634f84a23ec6fa"
+        }
+      ],
+      "licenses": [],
+      "cpe": "cpe:2.3:a:next:next:11.1.4_6ae8aab56bccab9c135b13f4dcebcfdd:*:*:*:*:*:*:*",
+      "purl": "pkg:npm/next@11.1.4_6ae8aab56bccab9c135b13f4dcebcfdd",
+      "externalReferences": [],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "javascript-lock-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "javascript"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "npm"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:*:next:11.1.4_6ae8aab56bccab9c135b13f4dcebcfdd:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "client/pnpm-lock.yaml"
+        }
+      ]
     }
   ],
   "externalReferences": [

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -234,7 +234,7 @@ func (a App) SBOMsFromFilesystem(config *SBOMsFromFilesystemConfig) {
 		return
 	}
 
-	sboms, err = bomtools.MergeBoms(sboms)
+	sboms, err = bomtools.MergeSBOMs(sboms)
 	if err != nil {
 		log.WithError(err).Fatal(errMsg)
 	}

--- a/pkg/bomtools/merge_test.go
+++ b/pkg/bomtools/merge_test.go
@@ -39,15 +39,32 @@ func TestMergeBoms(t *testing.T) {
 			"pkg:npm/actions/artifact@0.3.2",
 			"pkg:golang/github.com/pelletier/go-toml@1.8.1",
 			"pkg:golang/github.com/pelletier/go-toml@1.8.1",
+			"pkg:npm/next@11.1.4",
 		}, gotPURLs)
 	})
 
+	t.Run("normalize CPEs correctly", func(t *testing.T) {
+		got := normalizeCPEs(bomFromFile("../../integration/test/bomtools/normalize-cpes-bom.json"))
+		require.NotNil(t, got)
+		require.NotNil(t, got.Components)
+
+		var gotCPEs []string
+		for _, c := range *got.Components {
+			gotCPEs = append(gotCPEs, c.CPE)
+		}
+
+		assert.ElementsMatch(t, []string{
+			"cpe:2.3:a:pelletier:go-toml:v1.8.1:*:*:*:*:*:*:*",
+			"cpe:2.3:a:next:next:11.1.4:*:*:*:*:*:*:*",
+		}, gotCPEs)
+	})
+
 	t.Run("return errors when merging nil or empty list collectors", func(t *testing.T) {
-		got, err := MergeBoms([]*cdx.BOM{}...)
+		got, err := MergeSBOMs([]*cdx.BOM{}...)
 		assert.Nil(t, got)
 		assert.ErrorIs(t, ErrNoBOMsToMerge, err)
 
-		got, err = MergeBoms(nil, nil)
+		got, err = MergeSBOMs(nil, nil)
 		assert.Nil(t, got)
 		assert.ErrorIs(t, ErrNoBOMsToMerge, err)
 	})
@@ -58,7 +75,7 @@ func TestMergeBoms(t *testing.T) {
 		thirdBOM := bomFromFile("../../integration/test/bomtools/bom-to-merge-3.json")
 
 		expectedBOM := bomFromFile("../../integration/test/bomtools/expected-merged-boms.json")
-		got, err := MergeBoms(firstBOM, secondBOM, thirdBOM)
+		got, err := MergeSBOMs(firstBOM, secondBOM, thirdBOM)
 		require.NoError(t, err)
 
 		assert.Equal(t, *expectedBOM.Components, *got.Components)

--- a/pkg/collectors/jvm.go
+++ b/pkg/collectors/jvm.go
@@ -66,7 +66,7 @@ func (j JVM) GenerateBOM(ctx context.Context, bomRoot string) (*cdx.BOM, error) 
 		return singleModeBom, nil
 	}
 
-	return bomtools.MergeBoms(singleModeBom, multiModeBom)
+	return bomtools.MergeSBOMs(singleModeBom, multiModeBom)
 }
 
 // BootstrapLanguageFiles implements LanguageCollector interface

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -186,7 +186,7 @@ func (r Repository) ExtractSBOMs(ctx context.Context, includeGenericCollectors b
 				Time to merge those SBOMs into a single one
 			*/
 
-			mergedSBOM, err := bomtools.MergeBoms(sbomsFromCollector...)
+			mergedSBOM, err := bomtools.MergeSBOMs(sbomsFromCollector...)
 			if err == nil {
 				// Append merged SBOM from this collector & move on to the next one
 				collectedSBOMs = append(collectedSBOMs, mergedSBOM)
@@ -205,7 +205,7 @@ func (r Repository) ExtractSBOMs(ctx context.Context, includeGenericCollectors b
 		return nil, ctx.Err()
 	default:
 		// All collectors are finished - merge collected SBOMs into a single one
-		merged, err := bomtools.MergeBoms(collectedSBOMs...)
+		merged, err := bomtools.MergeSBOMs(collectedSBOMs...)
 		if err != nil {
 			return nil, fmt.Errorf("%s: ExtractSBOMs can't merge sboms - %s", r, err)
 		}


### PR DESCRIPTION
Previously some components had trailing checksum in their PURL & CPE strings. E.g. 
`cpe:2.3:a:next:next:11.1.4_6ae8aab56bccab9c135b13f4dcebcfdd:*:*:*:*:*:*:*`
or
`pkg:npm/next@11.1.4_6ae8aab56bccab9c135b13f4dcebcfdd`

This would cause Dependency Track analyzer to miss vulnerabilities for these packages. This commit now strips all checksums from PURLs & CPEs

Signed-off-by: Ugnius Vaznys <ugnius.vaznys@vinted.com>