### PR TITLE
Add a function to strip CPEs from components

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/elliotchance/sshtunnel v1.3.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/facebookincubator/nvdtools v0.1.5 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
@@ -108,11 +109,11 @@ require (
 	github.com/wagoodman/go-progress v0.0.0-20220614130704-4b1c25a33c7c // indirect
 	github.com/xanzy/ssh-agent v0.3.2 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
-	golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b // indirect
+	golang.org/x/crypto v0.0.0-20221012134737-56aed061732a // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20221004154528-8021a29435af // indirect
 	golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0 // indirect
-	golang.org/x/sys v0.0.0-20221006211917-84dc82d7e875 // indirect
+	golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43 // indirect
 	golang.org/x/text v0.3.8-0.20211004125949-5bd84dd9b33b // indirect
 	golang.org/x/tools v0.1.12 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -481,6 +481,8 @@ github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:Htrtb
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
+github.com/elliotchance/sshtunnel v1.3.1 h1:F2CtWqIMv81gSLi6yjQepo99u3bWhn/cRmVfbW4DE8s=
+github.com/elliotchance/sshtunnel v1.3.1/go.mod h1:gRPilFGawrilzilJ+4ySFZxu/qoNZN++GQQ1HVFrVJk=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
@@ -1527,6 +1529,7 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -1545,6 +1548,8 @@ golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 h1:Y/gsMcFOcR+6S6f3YeMKl5
 golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b h1:huxqepDufQpLLIRXiVkTvnxrzJlpwmIWAObmcCcUFr0=
 golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20221012134737-56aed061732a h1:NmSIgad6KjE6VvHciPZuNRTKxGhlPfD6OA87W/PLkqg=
+golang.org/x/crypto v0.0.0-20221012134737-56aed061732a/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1822,6 +1827,8 @@ golang.org/x/sys v0.0.0-20220907062415-87db552b00fd h1:AZeIEzg+8RCELJYq8w+ODLVxF
 golang.org/x/sys v0.0.0-20220907062415-87db552b00fd/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20221006211917-84dc82d7e875 h1:AzgQNqF+FKwyQ5LbVrVqOcuuFB67N47F9+htZYH0wFM=
 golang.org/x/sys v0.0.0-20221006211917-84dc82d7e875/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43 h1:OK7RB6t2WQX54srQQYSXMW8dF5C6/8+oA/s5QBmmto4=
+golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/integration/test/bomtools/syft-bom-with-cpes.json
+++ b/integration/test/bomtools/syft-bom-with-cpes.json
@@ -1,0 +1,133 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "serialNumber": "urn:uuid:a19c95eb-b50f-4fd7-b0b3-dba5d2f79c29",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2022-11-04T11:25:21Z",
+    "tools": [
+      {
+        "vendor": "anchore",
+        "name": "syft",
+        "version": "0.60.3"
+      }
+    ],
+    "component": {
+      "bom-ref": "7fc7d3b2280ffeed",
+      "type": "file",
+      "name": "/var/lib/rpm"
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "pkg:rpm/yum-utils@1.1.31-54.el7_8?arch=noarch\u0026upstream=yum-utils-1.1.31-54.el7_8.src.rpm\u0026package-id=f872ccf389426a04",
+      "type": "library",
+      "publisher": "CentOS",
+      "name": "yum-utils",
+      "version": "1.1.31-54.el7_8",
+      "cpe": "cpe:2.3:a:yum-utils:yum-utils:1.1.31-54.el7_8:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/yum-utils@1.1.31-54.el7_8?arch=noarch\u0026upstream=yum-utils-1.1.31-54.el7_8.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "RpmMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:yum-utils:yum_utils:1.1.31-54.el7_8:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:yum_utils:yum-utils:1.1.31-54.el7_8:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:yum_utils:yum_utils:1.1.31-54.el7_8:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:centos:yum-utils:1.1.31-54.el7_8:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:centos:yum_utils:1.1.31-54.el7_8:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:yum:yum-utils:1.1.31-54.el7_8:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:yum:yum_utils:1.1.31-54.el7_8:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "Packages"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "54.el7_8"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "345576"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "yum-utils-1.1.31-54.el7_8.src.rpm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:rpm/zlib@1.2.7-20.el7_9?arch=x86_64\u0026upstream=zlib-1.2.7-20.el7_9.src.rpm\u0026package-id=c395a5d801d43baf",
+      "type": "library",
+      "publisher": "CentOS",
+      "name": "zlib",
+      "version": "1.2.7-20.el7_9",
+      "cpe": "cpe:2.3:a:centos:zlib:1.2.7-20.el7_9:*:*:*:*:*:*:*",
+      "purl": "pkg:rpm/zlib@1.2.7-20.el7_9?arch=x86_64\u0026upstream=zlib-1.2.7-20.el7_9.src.rpm",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "rpm-db-cataloger"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "RpmMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:zlib:zlib:1.2.7-20.el7_9:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "Packages"
+        },
+        {
+          "name": "syft:metadata:release",
+          "value": "20.el7_9"
+        },
+        {
+          "name": "syft:metadata:size",
+          "value": "185206"
+        },
+        {
+          "name": "syft:metadata:sourceRpm",
+          "value": "zlib-1.2.7-20.el7_9.src.rpm"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/bomtools/filters.go
+++ b/pkg/bomtools/filters.go
@@ -41,3 +41,22 @@ func FilterOutComponentsWithoutAType(sbom *cdx.BOM) *cdx.BOM {
 
 	return sbom
 }
+
+// StripCPEsFromComponents Remove CPEs from all SBOM components
+func StripCPEsFromComponents(sbom *cdx.BOM) *cdx.BOM {
+	if sbom == nil || sbom.Components == nil || len(*sbom.Components) == 0 {
+		return sbom
+	}
+
+	requiredComponents := make([]cdx.Component, 0, len(*sbom.Components))
+
+	for _, c := range *sbom.Components {
+		updatedComponent := c
+		updatedComponent.CPE = ""
+		requiredComponents = append(requiredComponents, updatedComponent)
+	}
+
+	sbom.Components = &requiredComponents
+
+	return sbom
+}

--- a/pkg/bomtools/filters_test.go
+++ b/pkg/bomtools/filters_test.go
@@ -84,3 +84,21 @@ func TestFilterOutComponentsWithoutAType(t *testing.T) {
 		assert.Equal(t, bom, FilterOutComponentsWithoutAType(bom))
 	})
 }
+
+func TestStripCPEs(t *testing.T) {
+	const testFilePath = "../../integration/test/bomtools/syft-bom-with-cpes.json"
+	testBOM, err := os.ReadFile(testFilePath)
+	if err != nil {
+		t.Fatalf("can't read a test file: %s", err)
+	}
+	bom, err := StringToCDX(testBOM)
+	if err != nil {
+		t.Fatalf("can't convert BOM string to cdx.BOM instance %s", err)
+	}
+
+	got := StripCPEsFromComponents(bom)
+
+	for _, c := range *got.Components {
+		assert.Empty(t, c.CPE)
+	}
+}


### PR DESCRIPTION
This commit adds a StripCPEsFromComponents function which will later be used to strip CPEs off from server SBOMs as those are not really relevant and only produce noise inside Dependency Track

Signed-off-by: Ugnius Vaznys <ugnius.vaznys@vinted.com>