### PR TITLE
Optimise CI pipeline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,5 @@
 name: Lint-Jobs
 on:
-  push:
-    branches:
-      - master
-      - main
   pull_request:
 permissions:
   contents: read

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,10 +1,5 @@
 name: SAST
 on:
-  push:
-    branches:
-      - master
-      - main
-      - develop
   pull_request:
 jobs:
   semgrep:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,9 +1,5 @@
 name: Test-Jobs
 on:
-  push:
-    branches:
-      - master
-      - main
   pull_request:
 jobs:
   unit-tests:


### PR DESCRIPTION
Don't run lint & unit test jobs on merged commits, these jobs will already be executed on pull requests. Due to branch protection rules, no failing PRs will be merged