### PR TITLE
Disable CGO when compiling

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-env GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o sa-collector
+env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -o sa-collector

--- a/build/push-to-cloudsmith.sh
+++ b/build/push-to-cloudsmith.sh
@@ -2,7 +2,7 @@
 releaseVersion=$(echo "$RELEASE" | tr '/' -)
 releaseName="sa-collector-$releaseVersion-$GOOS-$GOARCH"
 
-go build -ldflags "-s -w" -o "$releaseName"
+CGO_ENABLED=0 go build -ldflags "-s -w" -o "$releaseName"
 
 pip3 install cloudsmith-cli
 cloudsmith push raw "$CS_REPOSITORY" "$releaseName"


### PR DESCRIPTION
Disable CGO when compiling to make the binary more portable.