### PR TITLE
Bake in fs SBOM creation date to CycloneDX properties

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,10 +3,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/vinted/sbomsftw/pkg/dtrack"
 
@@ -114,7 +112,6 @@ func setupLogrus(logLevel, logFormat string) error {
 }
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -247,6 +247,8 @@ func (a App) SBOMsFromFilesystem(config *SBOMsFromFilesystemConfig) {
 		sboms = bomtools.StripCPEsFromComponents(sboms)
 	}
 
+	sboms = bomtools.SetCreatedAtProperty(sboms)
+
 	log.Infof("Collected %d SBOM components from %s", len(*sboms.Components), config.FilesystemPath)
 
 	if a.outputFile == "" {

--- a/pkg/bomtools/filters.go
+++ b/pkg/bomtools/filters.go
@@ -1,6 +1,11 @@
 package bomtools
 
-import cdx "github.com/CycloneDX/cyclonedx-go"
+import (
+	"fmt"
+	"time"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+)
 
 // FilterOutByScope Filter out SBOM components that don't have the specified scope
 func FilterOutByScope(sbom *cdx.BOM, scope cdx.Scope) *cdx.BOM {
@@ -57,6 +62,29 @@ func StripCPEsFromComponents(sbom *cdx.BOM) *cdx.BOM {
 	}
 
 	sbom.Components = &requiredComponents
+
+	return sbom
+}
+
+// SetCreatedAtProperty Bakes in the SBOM creation date as a CycloneDX property
+func SetCreatedAtProperty(sbom *cdx.BOM) *cdx.BOM {
+	if sbom == nil {
+		return nil
+	}
+
+	createdAt := cdx.Property{
+		Name:  "createdAt",
+		Value: fmt.Sprintf("%d", time.Now().Unix()),
+	}
+
+	if sbom.Properties == nil || len(*sbom.Properties) == 0 {
+		sbom.Properties = &[]cdx.Property{createdAt}
+		return sbom
+	}
+
+	// If some properties exist, simply append the 'createdAt' property
+	updatedProperties := append(*sbom.Properties, createdAt)
+	sbom.Properties = &updatedProperties
 
 	return sbom
 }


### PR DESCRIPTION
This commit adds an additional 'createdAt' CycloneDX property for SBOMs collected from filesystems.