### PR TITLE
Pin v1.52.2 version of golangci-lint for lint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,5 +15,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: v1.52.2
           args: --enable=gofumpt --timeout 3m --verbose


### PR DESCRIPTION
`golangci-lint` recently [broke](https://github.com/golangci/golangci-lint-action/issues/759). In order too make lint jobs pass, this commit pins down the latest working version