### PR TITLE
Add soft-exit

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ const (
 	classifierFlag     = "classifier"
 	uploadToDTrackFlag = "upload-to-dependency-track"
 	purgeCacheFlag     = "purge-cache"
+	softExitFlag       = "soft-exit"
 	orgFlag            = "organization"
 )
 
@@ -129,6 +130,7 @@ func init() {
 		tagsUsage                    = "tags to use when SBOMs are uploaded to Dependency Track (optional)"
 		purgeCacheUsage              = "whether to purge gradle and go caches after a successful run (default: false)"
 		orgFlagUsage                 = "used when using organization github app"
+		softExitUsage                = "used on cleanup to exit soft without crashing"
 	)
 
 	const classifierUsageTemplate = "classifier to use when uploading to Dependency Track. Valid values are: %s"
@@ -144,6 +146,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolP(uploadToDTrackFlag, "u", false, uploadToDependencyTrackUsage)
 
 	rootCmd.PersistentFlags().BoolP(purgeCacheFlag, "p", false, purgeCacheUsage)
+	rootCmd.PersistentFlags().BoolP(softExitFlag, "s", false, softExitUsage)
 
 	rootCmd.PersistentFlags().StringP(orgFlag, "g", "", orgFlagUsage)
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -46,6 +46,14 @@ func createAppFromCLI(cmd *cobra.Command, verbose bool) (*app.App, error) {
 		options = append(options, app.WithCachePurge())
 	}
 
+	softExit, err := cmd.Flags().GetBool(softExitFlag)
+	if err != nil {
+		return nil, fmt.Errorf(errTemplate, softExitFlag)
+	}
+	if softExit {
+		options = append(options, app.WithSoftExit())
+	}
+
 	if uploadToDependencyTrack {
 		classifier, err := cmd.Flags().GetString(classifierFlag)
 		if err != nil {


### PR DESCRIPTION
* Adding soft exit so when it is ran in a bash script, multiple orgs can be scanned without bash script getting error 2