### PR TITLE
Fix repo crawling

### DIFF
--- a/internal/requests_test.go
+++ b/internal/requests_test.go
@@ -71,6 +71,7 @@ func TestGetRepositories(t *testing.T) {
 
 		want := []repositoryMapping{
 			{Name: "xmlsec", Archived: false, Language: "C", URL: "https://github.com/vinted/xmlsec"},
+			{Name: "airbrake", Archived: true, Language: "Ruby", URL: "https://github.com/vinted/airbrake-graylog2"},
 			{Name: "dotpay", Archived: false, Language: "Ruby", URL: "https://github.com/vinted/dotpay"},
 		}
 		assert.Equal(t, want, repositories)

--- a/pkg/bomtools/merge.go
+++ b/pkg/bomtools/merge.go
@@ -201,8 +201,17 @@ func mergeAllByPURL(component *cdx.Component, allComponents []*cdx.Component) *c
 			mergedComponent.Properties = &p
 		}
 		if c.Licenses != nil {
-			l := mergeCollection[cdx.LicenseChoice](*c.Licenses, *mergedComponent.Licenses)
-			mergedComponent.Licenses = (*cdx.Licenses)(&l)
+			l := make([]cdx.LicenseChoice, 0)
+			for _, sl := range *c.Licenses {
+				// Check for license ID
+				if sl.License != nil && sl.License.ID != "" {
+					l = append(l, sl)
+				}
+			}
+
+			// Assuming mergedComponent.Licenses is initialized properly earlier
+			mergedLicenses := mergeCollection[cdx.LicenseChoice](l, *mergedComponent.Licenses)
+			mergedComponent.Licenses = (*cdx.Licenses)(&mergedLicenses)
 		}
 		if c.ExternalReferences != nil {
 			e := mergeCollection[cdx.ExternalReference](*c.ExternalReferences, *mergedComponent.ExternalReferences)

--- a/pkg/dtrack/http.go
+++ b/pkg/dtrack/http.go
@@ -67,11 +67,12 @@ func (d DependencyTrackClient) createProject(ctx context.Context, payload create
 	d.setRequiredHeaders(req)
 
 	resp, err := http.DefaultClient.Do(req)
-	log.WithField("funcType", "createProject").Debugf("CreateProject request response body: %s", resp.Body)
-	log.WithField("funcType", "createProject").Debugf("CreateProject request response status code: %v", resp.StatusCode)
 	if err != nil {
+		log.WithField("funcType", "createProject").Debugf("CreateProject error %v", err.Error())
 		return "", fmt.Errorf(cantPerformHTTPRequest, requestURL, err)
 	}
+	// putting err here incase we get a resp nil
+	log.WithField("funcType", "createProject").Debugf("CreateProject request response status code: %v", resp.StatusCode)
 
 	defer func() {
 		closeErr := resp.Body.Close()
@@ -125,11 +126,11 @@ func (d DependencyTrackClient) updateSBOMs(ctx context.Context, payload updateSB
 	d.setRequiredHeaders(req)
 
 	resp, err := http.DefaultClient.Do(req)
-	log.WithField("funcType", "updateSBOM").Debugf("CreateProject request response body: %s", resp.Body)
-	log.WithField("funcType", "updateSBOM").Debugf("CreateProject request response status code: %v", resp.StatusCode)
 	if err != nil {
 		return fmt.Errorf(cantPerformHTTPRequest, requestURL, err)
 	}
+	log.WithField("funcType", "updateSBOM").Debugf("CreateProject request response body: %s", resp.Body)
+	log.WithField("funcType", "updateSBOM").Debugf("CreateProject request response status code: %v", resp.StatusCode)
 
 	defer func() {
 		closeErr := resp.Body.Close()


### PR DESCRIPTION
* Update license fetch, so if no ID available - do not add it to the list of licenses
* Fix debug logs so when no resp available, not crash the app
* Update the crawling if page returns 30 archived repos - continue the execution