### PR TITLE
Fix empty name on package

### DIFF
--- a/pkg/bomtools/merge.go
+++ b/pkg/bomtools/merge.go
@@ -248,7 +248,10 @@ func MergeSBOMs(mergedSbomParam MergeSBOMParam) (*cdx.BOM, error) {
 		if b.Components != nil {
 			components := *b.Components
 			for i := range components {
-				allComponents = append(allComponents, &components[i])
+				// Seems that sometimes the name can return empty
+				if components[i].Name != "" {
+					allComponents = append(allComponents, &components[i])
+				}
 			}
 		}
 	}

--- a/pkg/collectors/jvm_test.go
+++ b/pkg/collectors/jvm_test.go
@@ -59,11 +59,11 @@ func TestJVMCollector(t *testing.T) {
 		const bomRoot = "/tmp/some-random-dir"
 		executor := new(mockShellExecutor)
 
-		firstBOMComponents := []cdx.Component{{PackageURL: "pkg:gem/addressable@2.4.0"}}
+		firstBOMComponents := []cdx.Component{{PackageURL: "pkg:gem/addressable@2.4.0", Name: "addressable"}}
 		firstBOM := new(cdx.BOM)
 		firstBOM.Components = &firstBOMComponents
 
-		secondBOMComponents := []cdx.Component{{PackageURL: "pkg:gem/addressable@2.4.1"}}
+		secondBOMComponents := []cdx.Component{{PackageURL: "pkg:gem/addressable@2.4.1", Name: "addressable"}}
 		secondBOM := new(cdx.BOM)
 		secondBOM.Components = &secondBOMComponents
 


### PR DESCRIPTION
* Sometimes syft returns a package with empty name, so we do not add it to list of packages to avoid processing issues in DT