### PR TITLE
Fix shorthand for fs app

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -162,7 +162,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolP(softExitFlag, "s", false, softExitUsage)
 
 	rootCmd.PersistentFlags().StringP(orgFlag, "g", "", orgFlagUsage)
-	rootCmd.PersistentFlags().StringSliceP(excludeReposFlag, "x", nil, excludeReposFlagUsage)
+	rootCmd.PersistentFlags().StringSlice(excludeReposFlag, nil, excludeReposFlagUsage)
 
 	rootCmd.PersistentFlags().IntP(pageCountFlag, "r", 0, pageCountFlagUsage)
 	rootCmd.PersistentFlags().IntP(pageIndexFlag, "y", 0, pageIndexFlagUsage)


### PR DESCRIPTION
* Fixing shorthand due to duplicate shorthand letter compilation error.