### PR TITLE
Updating shellout to use go-sh sessions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,8 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
+	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
+	github.com/codeskyblue/go-sh v0.0.0-20200712050446-30169cf553fe // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/containerd/containerd v1.7.27 // indirect
 	github.com/containerd/containerd/api v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,10 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211130200136-a8f946100490/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 h1:sDMmm+q/3+BukdIpxwO365v/Rbspp2Nt5XntgQRXq8Q=
+github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
+github.com/codeskyblue/go-sh v0.0.0-20200712050446-30169cf553fe h1:69JI97HlzP+PH5Mi1thcGlDoBr6PS2Oe+l3mNmAkbs4=
+github.com/codeskyblue/go-sh v0.0.0-20200712050446-30169cf553fe/go.mod h1:VQx0hjo2oUeQkQUET7wRwradO6f+fN5jzXgB/zROxxE=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/containerd v1.7.27 h1:yFyEyojddO3MIGVER2xJLWoCIn+Up4GaHFquP7hsFII=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/vinted/sbomsftw/internal"
 	"net/http"
 	"net/url"
 	"os"
@@ -13,6 +12,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/vinted/sbomsftw/internal"
 
 	"github.com/vinted/sbomsftw/pkg"
 

--- a/pkg/collectors/jvm.go
+++ b/pkg/collectors/jvm.go
@@ -2,10 +2,11 @@ package collectors
 
 import (
 	"context"
+	fp "path/filepath"
+
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/vinted/sbomsftw/pkg/bomtools"
-	fp "path/filepath"
 )
 
 type JVM struct {

--- a/pkg/collectors/jvm.go
+++ b/pkg/collectors/jvm.go
@@ -72,10 +72,8 @@ func (j JVM) GenerateBOM(ctx context.Context, bomRoot string) (*cdx.BOM, error) 
 }
 
 // BootstrapLanguageFiles implements LanguageCollector interface
-// BootstrapLanguageFiles implements LanguageCollector interface
 func (j JVM) BootstrapLanguageFiles(ctx context.Context, bomRoots []string) []string {
 	const bootstrapCmd = "./gradlew"
-	const cleanupCmd = "./gradlew --stop"
 
 	for dir, files := range SplitPaths(bomRoots) {
 		for _, f := range files {
@@ -97,20 +95,6 @@ func (j JVM) BootstrapLanguageFiles(ctx context.Context, bomRoots []string) []st
 					"collector":       j,
 					"collection path": dir,
 				}).Debug("gradle cache primed successfully")
-
-				// Add cleanup - stop Gradle daemon
-				log.WithFields(log.Fields{
-					"collector":       j,
-					"collection path": dir,
-				}).Debug("stopping gradle daemon")
-				log.Warnf("attempting to cleanup cmd gradle")
-				if err := j.executor.shellOut(ctx, dir, cleanupCmd); err != nil {
-					log.WithFields(log.Fields{
-						"error":           err,
-						"collector":       j,
-						"collection path": dir,
-					}).Debug("failed to stop gradle daemon")
-				}
 			}
 		}
 	}

--- a/pkg/collectors/python_test.go
+++ b/pkg/collectors/python_test.go
@@ -2,10 +2,11 @@ package collectors
 
 import (
 	"context"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"path/filepath"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/stretchr/testify/assert"

--- a/pkg/collectors/shell.go
+++ b/pkg/collectors/shell.go
@@ -3,10 +3,11 @@ package collectors
 import (
 	"context"
 	"fmt"
-	"github.com/codeskyblue/go-sh"
 	"os"
 	"os/exec"
 	"time"
+
+	"github.com/codeskyblue/go-sh"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	log "github.com/sirupsen/logrus"

--- a/pkg/collectors/shell.go
+++ b/pkg/collectors/shell.go
@@ -143,7 +143,7 @@ func cleanupNewProcesses(pidsBefore map[int]struct{}) {
 				strings.Contains(execName, "maven") ||
 				strings.Contains(execName, "cdxgen") {
 
-				log.Debugf("Terminating leftover process: %s (PID: %d)", p.Executable(), p.Pid())
+				log.Debugf("Terminating leftover process: %s (PID: %d)", execName, p.Pid())
 				killProcess(p.Pid())
 			}
 		}

--- a/pkg/collectors/shell.go
+++ b/pkg/collectors/shell.go
@@ -33,7 +33,7 @@ func (d defaultShellExecutor) bomFromCdxgen(ctx context.Context, bomRoot string,
 			multiModuleModeConfig = "unset GRADLE_MULTI_PROJECT_MODE"
 		}
 
-		return fmt.Sprintf("%s && %s && cdxgen --no-install-deps --type %s -o %s", licenseConfig, multiModuleModeConfig, language, outputFile)
+		return fmt.Sprintf("%s && %s && cdxgen --type %s -o %s", licenseConfig, multiModuleModeConfig, language, outputFile)
 	}
 
 	f, err := os.CreateTemp("/tmp", "sa-collector-tmp-output-")

--- a/pkg/collectors/shell.go
+++ b/pkg/collectors/shell.go
@@ -33,7 +33,7 @@ func (d defaultShellExecutor) bomFromCdxgen(ctx context.Context, bomRoot string,
 			multiModuleModeConfig = "unset GRADLE_MULTI_PROJECT_MODE"
 		}
 
-		return fmt.Sprintf("%s && %s && cdxgen --type %s -o %s", licenseConfig, multiModuleModeConfig, language, outputFile)
+		return fmt.Sprintf("%s && %s && cdxgen --no-install-deps --type %s -o %s", licenseConfig, multiModuleModeConfig, language, outputFile)
 	}
 
 	f, err := os.CreateTemp("/tmp", "sa-collector-tmp-output-")

--- a/pkg/collectors/syft.go
+++ b/pkg/collectors/syft.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/format/cyclonedxjson"

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -142,7 +142,7 @@ func New(ctx context.Context, vcsURL string, credentials Credentials) (*Reposito
 			collectors.Syft{}, collectors.CDXGen{}, collectors.RetireJS{},
 		},
 		languageCollectors: []pkg.LanguageCollector{
-			collectors.NewPythonCollector(), collectors.NewRustCollector(),
+			collectors.NewPythonCollector(), collectors.NewRustCollector(), collectors.NewJVMCollector(),
 			collectors.NewGolangCollector(), collectors.NewJSCollector(), collectors.NewRubyCollector(),
 		},
 	}, nil

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -15,10 +20,6 @@ import (
 	"github.com/vinted/sbomsftw/pkg"
 	"github.com/vinted/sbomsftw/pkg/bomtools"
 	"github.com/vinted/sbomsftw/pkg/collectors"
-	"path/filepath"
-	"sort"
-	"strings"
-	"sync"
 )
 
 const CheckoutsPath = "/tmp/checkouts/"

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -142,7 +142,7 @@ func New(ctx context.Context, vcsURL string, credentials Credentials) (*Reposito
 			collectors.Syft{}, collectors.CDXGen{}, collectors.RetireJS{},
 		},
 		languageCollectors: []pkg.LanguageCollector{
-			collectors.NewPythonCollector(), collectors.NewRustCollector(), collectors.NewJVMCollector(),
+			collectors.NewPythonCollector(), collectors.NewRustCollector(),
 			collectors.NewGolangCollector(), collectors.NewJSCollector(), collectors.NewRubyCollector(),
 		},
 	}, nil


### PR DESCRIPTION
Using go-sh showed some more issues underneat the processer of cdxgen, so this is a semi revert, but reverting to use `go-sh` sessions instead of `cmd.WithContext` 