### PR TITLE
Fix for silent CDXGen failure

### DIFF
--- a/pkg/collectors/shell.go
+++ b/pkg/collectors/shell.go
@@ -49,7 +49,7 @@ func (d defaultShellExecutor) bomFromCdxgen(
 	}
 
 	log.WithError(err).
-		Debug("Failed to generate SBOMs with licensing information. Attempting to generate SBOMs without licensing information.")
+		Warning("Failed to generate SBOMs with licensing information. Attempting to generate SBOMs without licensing information.")
 
 	withoutLicencesCommand := formatCommand(multiModuleMode, false, language, outputFile)
 	sbom, err = generate(ctx, bomRoot, outputFile, withoutLicencesCommand, 10*time.Minute)
@@ -58,7 +58,7 @@ func (d defaultShellExecutor) bomFromCdxgen(
 	}
 
 	log.WithError(err).
-		Debug("Failed to generate SBOMs with and without licensing information.")
+		Error("Failed to generate SBOMs with and without licensing information.")
 
 	return nil, err
 }


### PR DESCRIPTION
On certain projects, CDXGen fails silently, but still returns
exit code 0. As we assume that the program ran successfuly,
we attempt to open the generated SBOM file and fail.

The fix/refactor makes it so that failing to read a file is
considered a failure on a single command level, not the
entire attempt to generate. We will retry the generation
with no licences, and that should not fail directly.