### PR TITLE
Refactor DependencyTrackClient for clarity and resilience

### DIFF
--- a/pkg/dtrack/client.go
+++ b/pkg/dtrack/client.go
@@ -23,12 +23,12 @@ func GetValidClassifiersString() string {
 }
 
 type DependencyTrackClient struct {
-	baseURL, apiToken, middlewareUrl string
-	classifier                       string
-	requestTimeout                   time.Duration
-	middleware                       bool
-	httpClient                       *http.Client
-	middlewareUser, middlewarePass   string
+	dependencyTrackUrl, apiToken, middlewareUrl string
+	classifier                                  string
+	requestTimeout                              time.Duration
+	middleware                                  bool
+	httpClient                                  *http.Client
+	middlewareUser, middlewarePass              string
 }
 
 type options struct {
@@ -101,24 +101,25 @@ func NewClient(baseURL, apiToken string, opts ...Option) (*DependencyTrackClient
 	client := new(DependencyTrackClient)
 
 	// Mandatory parameters
-	client.baseURL = baseURL
+	client.dependencyTrackUrl = baseURL
 	client.apiToken = apiToken
 	// Optional parameters
-	const defaultTimeout = 180
 
 	if options.middleware {
 		client.middleware = true
 		client.middlewareUrl = options.middlewareUrl
 		client.middlewareUser = options.middlewareUser
 		client.middlewarePass = options.middlewarePass
-		client.httpClient = &http.Client{Timeout: 60 * time.Second}
 	}
 
+	const defaultTimeout = 180
 	if options.requestTimeout == 0 { // If timeout is not provided - use default value
 		client.requestTimeout = time.Second * time.Duration(defaultTimeout)
 	} else {
 		client.requestTimeout = options.requestTimeout
 	}
+
+	client.httpClient = &http.Client{}
 
 	if options.classifier == "" {
 		client.classifier = ValidClassifiers[0]


### PR DESCRIPTION
### Changelog

#### Refactoring and Improvements
- Renamed `baseURL` to `dependencyTrackUrl` for clarity.
- Moved HTTP client initialization to be used generally.
- Removed the `appendURLPath` method; replaced with `url.JoinPath` for constructing URLs.
- Introduced exponential backoff mechanism for retrying HTTP requests to enhance resilience.

#### Error Handling
- Improved error messages for URL joining and request construction.
- Used `json.Unmarshal` instead of `json.NewDecoder().Decode()` for more generalized JSON parsing.

#### Testing
- Updated tests to reflect method renaming (`updateSBOMs` to `updateDependencyTrackSBOMs`).
- Due to `json.Unmarshal` usage, updated error assertion in tests from `io.EOF` to `json.SyntaxError`.