### PR TITLE
ISEN-369: Update build command for glibc

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-CGO_ENABLED=1 go build -tags "sqlite_json sqlite_fts5 sqlite_math_functions sqlite3" -ldflags "-s -w" -o sa-collector
+CGO_ENABLED=0 go build -tags "sqlite_json sqlite_fts5 sqlite_math_functions sqlite3" -ldflags "-s -w" -o sa-collector

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-CGO_ENABLED=0 go build -tags "sqlite_json sqlite_fts5 sqlite_math_functions sqlite3" -ldflags "-s -w" -o sa-collector
+CGO_ENABLED=1 go build -tags "sqlite_json sqlite_fts5 sqlite_math_functions sqlite3" -ldflags "-s -w -linkmode external -extldflags -static" -o sa-collector

--- a/build/push-to-cloudsmith.sh
+++ b/build/push-to-cloudsmith.sh
@@ -2,7 +2,7 @@
 releaseVersion=$(echo "$RELEASE" | tr '/' -)
 releaseName="sa-collector-$releaseVersion-$GOOS-$GOARCH"
 
-CGO_ENABLED=0 go build -tags "sqlite_json sqlite_fts5 sqlite_math_functions sqlite3" -ldflags "-s -w" -o "$releaseName"
+CGO_ENABLED=1 go build -tags "sqlite_json sqlite_fts5 sqlite_math_functions sqlite3" -ldflags "-s -w" -o "$releaseName"
 
 pip3 install cloudsmith-cli
 cloudsmith push raw "$CS_REPOSITORY" "$releaseName"

--- a/build/push-to-cloudsmith.sh
+++ b/build/push-to-cloudsmith.sh
@@ -2,7 +2,7 @@
 releaseVersion=$(echo "$RELEASE" | tr '/' -)
 releaseName="sa-collector-$releaseVersion-$GOOS-$GOARCH"
 
-CGO_ENABLED=1 go build -tags "sqlite_json sqlite_fts5 sqlite_math_functions sqlite3" -ldflags "-s -w" -o "$releaseName"
+CGO_ENABLED=0 go build -tags "sqlite_json sqlite_fts5 sqlite_math_functions sqlite3" -ldflags "-s -w" -o "$releaseName"
 
 pip3 install cloudsmith-cli
 cloudsmith push raw "$CS_REPOSITORY" "$releaseName"

--- a/build/push-to-cloudsmith.sh
+++ b/build/push-to-cloudsmith.sh
@@ -2,7 +2,7 @@
 releaseVersion=$(echo "$RELEASE" | tr '/' -)
 releaseName="sa-collector-$releaseVersion-$GOOS-$GOARCH"
 
-CGO_ENABLED=1 go build -tags "sqlite_json sqlite_fts5 sqlite_math_functions sqlite3" -ldflags "-s -w" -o "$releaseName"
+CGO_ENABLED=1 go build -tags "sqlite_json sqlite_fts5 sqlite_math_functions sqlite3" -ldflags "-s -w -linkmode external -extldflags -static" -o "$releaseName"
 
 pip3 install cloudsmith-cli
 cloudsmith push raw "$CS_REPOSITORY" "$releaseName"


### PR DESCRIPTION
As we build in ubuntu env, we need to basically build with glibc inside for it to run on RHEL systems. 

This was tested in a simple docker env:
```
# Build stage - Ubuntu
FROM ubuntu:latest AS builder

RUN apt-get update && apt-get install -y \
    curl \
    tar \
    git \
    golang-go \
    && rm -rf /var/lib/apt/lists/*

RUN git clone -b 'builder' https://github.com/vinted/sbomsftw.git /builder \
    && cd /builder \
    && build/build.sh

# Runtime stage - Red Hat UBI9
FROM redhat/ubi9:latest

RUN dnf -y update

# Copy the built binary from the builder stage
COPY --from=builder /builder/sa-collector /usr/local/bin/

ENTRYPOINT ["/bin/bash"]
```